### PR TITLE
feat(ci): auto version bump, tag, and changelog on merge to main

### DIFF
--- a/.ci/changelog.php
+++ b/.ci/changelog.php
@@ -1,0 +1,176 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Changelog generator for Wicket WordPress plugins.
+ *
+ * Prepends a section for the given version to CHANGELOG.md, built from the git
+ * commits merged since the most recent tag. Intended to run in CI immediately
+ * after the version bump and before the release commit, so the changelog entry
+ * ships in the same commit the tag points at.
+ *
+ * Usage:
+ *   php .ci/changelog.php 2.4.12                  # range = <last tag>..HEAD
+ *   php .ci/changelog.php 2.4.12 2.4.8..HEAD      # explicit range override
+ *
+ * Every commit type is included (grouped into a section). The only commits
+ * skipped are the bot's own "chore(release):" commits, which are the changelog
+ * commits themselves and would be circular noise. Merge commits are ignored.
+ */
+
+class ChangelogGenerator
+{
+    private const FILE = 'CHANGELOG.md';
+    private const MARKER = '<!-- new releases inserted below this line -->';
+
+    private const HEADER = "# Changelog\n\n"
+        . "All notable changes to this plugin are documented in this file.\n"
+        . "This project adheres to [Semantic Versioning](https://semver.org/).\n\n"
+        . self::MARKER . "\n";
+
+    /** Conventional-commit type => changelog section heading. */
+    private array $typeMap = [
+        'feat' => 'Added',
+        'fix' => 'Fixed',
+        'perf' => 'Performance',
+        'refactor' => 'Changed',
+        'docs' => 'Documentation',
+        'test' => 'Tests',
+        'build' => 'Build',
+        'ci' => 'CI',
+        'chore' => 'Maintenance',
+        'style' => 'Maintenance',
+    ];
+
+    /** Order sections appear in the changelog. Anything else is "Other". */
+    private array $sectionOrder = [
+        'Added',
+        'Changed',
+        'Fixed',
+        'Performance',
+        'Documentation',
+        'Tests',
+        'Build',
+        'CI',
+        'Maintenance',
+        'Other',
+    ];
+
+    public function run(string $newVersion, ?string $rangeOverride = null): void
+    {
+        $range = ($rangeOverride !== null && $rangeOverride !== '') ? $rangeOverride : $this->commitRange();
+        $subjects = $this->commitSubjects($range);
+        $sections = $this->groupSubjects($subjects);
+        $block = $this->renderBlock($newVersion, $sections);
+
+        $this->prepend($block);
+
+        fwrite(STDERR, "Wrote changelog entry for {$newVersion} (" . count($subjects) . " commits from range '{$range}').\n");
+    }
+
+    /** Range = <last tag>..HEAD, or the full history if there are no tags yet. */
+    private function commitRange(): string
+    {
+        $prevTag = trim((string) shell_exec('git describe --tags --abbrev=0 HEAD 2>/dev/null'));
+
+        return $prevTag !== '' ? $prevTag . '..HEAD' : 'HEAD';
+    }
+
+    /** @return string[] commit subject lines, newest first, merges excluded */
+    private function commitSubjects(string $range): array
+    {
+        $cmd = 'git log ' . escapeshellarg($range) . ' --no-merges --pretty=format:%s';
+        $out = (string) shell_exec($cmd);
+
+        $subjects = array_filter(array_map('trim', explode("\n", $out)), static fn ($s) => $s !== '');
+
+        // Skip the bot's own release commits.
+        return array_values(array_filter($subjects, static fn ($s) => !preg_match('/^chore\(release\)/i', $s)));
+    }
+
+    /**
+     * @param string[] $subjects
+     * @return array<string, string[]> section heading => rendered lines
+     */
+    private function groupSubjects(array $subjects): array
+    {
+        $sections = [];
+
+        foreach ($subjects as $subject) {
+            if (preg_match('/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/', $subject, $m)) {
+                $type = strtolower($m[1]);
+                $scope = $m[2];
+                $breaking = $m[3] === '!';
+                $desc = $m[4];
+                $section = $this->typeMap[$type] ?? 'Other';
+            } else {
+                // Non-conventional subject: keep it verbatim under "Other".
+                $scope = '';
+                $breaking = false;
+                $desc = $subject;
+                $section = 'Other';
+            }
+
+            $line = '- '
+                . ($breaking ? '**BREAKING** ' : '')
+                . ($scope !== '' ? '**' . $scope . ':** ' : '')
+                . $desc;
+
+            $sections[$section][] = $line;
+        }
+
+        return $sections;
+    }
+
+    /** @param array<string, string[]> $sections */
+    private function renderBlock(string $newVersion, array $sections): string
+    {
+        $date = date('Y-m-d');
+        $block = "## [{$newVersion}] - {$date}\n";
+
+        if ($sections === []) {
+            return $block . "\n_Maintenance release; no recorded changes._\n";
+        }
+
+        foreach ($this->sectionOrder as $heading) {
+            if (empty($sections[$heading])) {
+                continue;
+            }
+            $block .= "\n### {$heading}\n" . implode("\n", $sections[$heading]) . "\n";
+        }
+
+        return $block;
+    }
+
+    private function prepend(string $block): void
+    {
+        if (!file_exists(self::FILE)) {
+            file_put_contents(self::FILE, self::HEADER);
+        }
+
+        $content = (string) file_get_contents(self::FILE);
+
+        if (!str_contains($content, self::MARKER)) {
+            // File exists but has no marker: put the header (with marker) on top.
+            $content = self::HEADER . "\n" . ltrim($content);
+        }
+
+        $needle = self::MARKER;
+        $insertAt = strpos($content, $needle) + strlen($needle);
+        $newContent = substr($content, 0, $insertAt) . "\n\n" . rtrim($block) . "\n" . substr($content, $insertAt);
+
+        if (file_put_contents(self::FILE, $newContent) === false) {
+            fwrite(STDERR, "Error: unable to write " . self::FILE . "\n");
+            exit(1);
+        }
+    }
+}
+
+global $argv;
+
+if (empty($argv[1])) {
+    fwrite(STDERR, "Usage: php .ci/changelog.php <new-version>\n");
+    exit(1);
+}
+
+(new ChangelogGenerator())->run(trim($argv[1]), isset($argv[2]) ? trim($argv[2]) : null);

--- a/.ci/version-bump.php
+++ b/.ci/version-bump.php
@@ -1,232 +1,280 @@
 #!/usr/bin/env php
 <?php
 
+/**
+ * Version bumper for Wicket WordPress plugins and themes.
+ *
+ * Detects the project's main file automatically:
+ *   - a plugin: the root *.php whose header contains "Plugin Name:"
+ *   - a theme:  style.css (header "Theme Name:")
+ *
+ * The current version is read from composer.json when present, otherwise from
+ * the main file's "Version:" header. The new version is written to the main
+ * file's header and to composer.json when that file exists.
+ *
+ * Usage:
+ *   php .ci/version-bump.php patch      # 2.4.10 -> 2.4.11
+ *   php .ci/version-bump.php minor      # 2.4.10 -> 2.5.0
+ *   php .ci/version-bump.php major      # 2.4.10 -> 3.0.0
+ *   php .ci/version-bump.php 2.4.11     # set an explicit version
+ *   php .ci/version-bump.php            # prompt interactively
+ *
+ * On success the resolved version is printed to STDOUT as the last line, so CI
+ * can capture it with: NEW_VERSION="$(php .ci/version-bump.php patch | tail -1)"
+ */
+
 class VersionBumper
 {
     private string $currentVersion;
-    private array $filesToUpdate = [
-        'composer.json',
-        'class-wicket-acc-main.php', // Wicket's Account Center plugin
-        'style.css' // Wicket's Theme
-    ];
+    private array $filesToUpdate = [];
+    private ?string $mainFile = null;
+    private bool $hasComposer = false;
 
-    /**
-     * Checks if the current directory is the root of the Wicket plugin.
-     * If not, the script will exit with an error code.
-     */
     public function __construct()
     {
-        if (!$this->getCurrentVersion()) {
+        $this->mainFile = $this->detectMainFile();
+
+        if ($this->mainFile === null && !file_exists('composer.json')) {
+            fwrite(STDERR, "Error: no composer.json and no main plugin/theme file found in current directory.\n");
             exit(1);
         }
+
+        if (!$this->resolveCurrentVersion()) {
+            exit(1);
+        }
+
+        if ($this->hasComposer) {
+            $this->filesToUpdate[] = 'composer.json';
+        }
+        if ($this->mainFile !== null) {
+            $this->filesToUpdate[] = $this->mainFile;
+        }
     }
 
     /**
-     * Tries to read the current version from composer.json.
-     * If the file does not exist, or the version field is not present,
-     * or the JSON is invalid, it will print an error message and return false.
-     * Otherwise, the current version is stored in the $currentVersion property and the method returns true.
-     *
-     * @return bool
+     * Plugin main file (root *.php with "Plugin Name:") or, failing that, a
+     * theme's style.css (with "Theme Name:").
      */
-    private function getCurrentVersion(): bool
+    private function detectMainFile(): ?string
     {
-        if (!file_exists('composer.json')) {
-            echo "Error: composer.json not found in current directory.\n";
-            return false;
+        foreach (glob('*.php') ?: [] as $file) {
+            $head = file_get_contents($file, false, null, 0, 4096);
+            if ($head !== false && preg_match('/Plugin Name:\s*\S/i', $head)) {
+                return $file;
+            }
         }
 
-        $composerJson = json_decode(file_get_contents('composer.json'), true);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            echo "Error: Unable to parse composer.json: " . json_last_error_msg() . "\n";
-            return false;
+        if (file_exists('style.css')) {
+            $head = file_get_contents('style.css', false, null, 0, 4096);
+            if ($head !== false && preg_match('/Theme Name:\s*\S/i', $head)) {
+                return 'style.css';
+            }
         }
 
-        if (!isset($composerJson['version'])) {
-            echo "Error: No version field found in composer.json\n";
-            return false;
-        }
-
-        $this->currentVersion = $composerJson['version'];
-        return true;
+        return null;
     }
 
-    /**
-     * Validate a given version string against the semantic versioning regex pattern.
-     * If the version string is invalid, an error message is printed and the method returns false.
-     * Otherwise, the method returns true.
-     *
-     * @param string $newVersion
-     * @return bool
-     */
+    /** Current version: composer.json if it has one, else the main file header. */
+    private function resolveCurrentVersion(): bool
+    {
+        if (file_exists('composer.json')) {
+            $composerJson = json_decode((string) file_get_contents('composer.json'), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                fwrite(STDERR, 'Error: Unable to parse composer.json: ' . json_last_error_msg() . "\n");
+                return false;
+            }
+            if (isset($composerJson['version'])) {
+                $this->hasComposer = true;
+                $this->currentVersion = $composerJson['version'];
+                return true;
+            }
+        }
+
+        if ($this->mainFile !== null) {
+            $version = $this->versionFromHeader($this->mainFile);
+            if ($version !== null) {
+                $this->currentVersion = $version;
+                return true;
+            }
+        }
+
+        fwrite(STDERR, "Error: could not determine current version from composer.json or the main file header.\n");
+        return false;
+    }
+
+    private function versionFromHeader(string $file): ?string
+    {
+        $content = (string) file_get_contents($file);
+        if (preg_match('/^\s*\*?\s*Version:\s*([0-9][0-9a-zA-Z.\-]*)/mi', $content, $m)) {
+            return $m[1];
+        }
+        return null;
+    }
+
     private function validateNewVersion(string $newVersion): bool
     {
-        // Semantic versioning regex pattern
         $semverPattern = '/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/';
 
         if (!preg_match($semverPattern, $newVersion)) {
-            echo "Error: Invalid version format. Please use semantic versioning (e.g., 1.2.3)\n";
+            fwrite(STDERR, "Error: Invalid version format. Please use semantic versioning (e.g., 1.2.3)\n");
             return false;
         }
 
         return true;
     }
 
-    /**
-     * Update the version string in a file by replacing the current version with a new one.
-     *
-     * @param string $filePath The path to the file to update.
-     * @param string $newVersion The new version string to use.
-     *
-     * @return bool True if the file was updated successfully, false otherwise.
-     */
+    private function computeBump(string $level): ?string
+    {
+        if (!preg_match('/^(\d+)\.(\d+)\.(\d+)/', $this->currentVersion, $m)) {
+            fwrite(STDERR, "Error: current version '{$this->currentVersion}' is not plain X.Y.Z; cannot compute a {$level} bump.\n");
+            return null;
+        }
+
+        [$major, $minor, $patch] = [(int) $m[1], (int) $m[2], (int) $m[3]];
+
+        switch ($level) {
+            case 'major':
+                return ($major + 1) . '.0.0';
+            case 'minor':
+                return $major . '.' . ($minor + 1) . '.0';
+            case 'patch':
+                return $major . '.' . $minor . '.' . ($patch + 1);
+        }
+
+        return null;
+    }
+
+    private function resolveNewVersion(?string $arg): ?string
+    {
+        if ($arg === null || $arg === '') {
+            fwrite(STDERR, 'Enter new version (semver) or bump level [patch|minor|major]: ');
+            $arg = trim((string) fgets(STDIN));
+        }
+
+        if (in_array($arg, ['patch', 'minor', 'major'], true)) {
+            return $this->computeBump($arg);
+        }
+
+        return $arg;
+    }
+
     private function updateVersionInFile(string $filePath, string $newVersion): bool
     {
         if (!file_exists($filePath)) {
-            echo "Warning: File not found: {$filePath}\n";
+            fwrite(STDERR, "Warning: File not found: {$filePath}\n");
             return false;
         }
 
         $content = file_get_contents($filePath);
         if ($content === false) {
-            echo "Error: Unable to read file: {$filePath}\n";
+            fwrite(STDERR, "Error: Unable to read file: {$filePath}\n");
             return false;
         }
 
-        // Handle different file types
         $extension = pathinfo($filePath, PATHINFO_EXTENSION);
-        $pattern = preg_quote($this->currentVersion, '/');
         $updated = false;
 
         switch ($extension) {
-            case 'css':
-                // For CSS files, look for Version: X.X.X pattern
-                $pattern = '/Version:\s*' . $pattern . '/i';
-                $newContent = preg_replace($pattern, 'Version: ' . $newVersion, $content, -1, $count);
-                $updated = $count > 0;
-                break;
             case 'json':
-                // For JSON files, look for "version": "X.X.X" pattern
-                $pattern = '/"version":\s*"' . $pattern . '"/';
+                $pattern = '/"version":\s*"' . preg_quote($this->currentVersion, '/') . '"/';
                 $newContent = preg_replace($pattern, '"version": "' . $newVersion . '"', $content, -1, $count);
                 $updated = $count > 0;
                 break;
             case 'php':
-                // Try both patterns for PHP files
-                // Pattern 1: Version: X.X.X with possible multiple spaces
-                $pattern1 = '/Version:\s+' . $pattern . '/';
-                $newContent = preg_replace($pattern1, 'Version:           ' . $newVersion, $content, -1, $count1);
-                
-                if ($count1 === 0) {
-                    // Pattern 2: Direct version number (fallback)
-                    $pattern2 = '/' . $pattern . '/';
-                    $newContent = preg_replace($pattern2, $newVersion, $content, -1, $count2);
-                    $updated = $count2 > 0;
-                } else {
-                    $updated = true;
+            case 'css':
+                // Header version, e.g. " * Version: 1.2.3" (php docblock) or
+                // "Version: 1.2.3" (css theme header).
+                $versionPatternPart = '[0-9a-zA-Z\\.-]+';
+                $headerPattern = '/(^\s*\*?\s*Version:\s*)' . $versionPatternPart . '/mi';
+                $newContent = preg_replace($headerPattern, '${1}' . $newVersion, $content, -1, $count);
+                $updated = $count > 0;
+
+                if ($extension === 'php') {
+                    // Keep any version constant in sync, e.g.
+                    //   define('MYPLUGIN_VERSION', '1.2.3');
+                    //   const VERSION = '1.2.3';
+                    $newContent = preg_replace(
+                        '/(define\(\s*[\'"][A-Z0-9_]*VERSION[\'"]\s*,\s*[\'"])' . $versionPatternPart . '([\'"]\s*\))/',
+                        '${1}' . $newVersion . '${2}',
+                        $newContent,
+                        -1,
+                        $countDefine
+                    );
+                    $newContent = preg_replace(
+                        '/(const\s+VERSION\s*=\s*[\'"])' . $versionPatternPart . '([\'"])/',
+                        '${1}' . $newVersion . '${2}',
+                        $newContent,
+                        -1,
+                        $countConst
+                    );
+                    $updated = $updated || ($countDefine + $countConst) > 0;
                 }
                 break;
             default:
-                // For other files, do direct version replacement
-                $pattern = '/' . $pattern . '/';
+                $pattern = '/' . preg_quote($this->currentVersion, '/') . '/';
                 $newContent = preg_replace($pattern, $newVersion, $content, -1, $count);
                 $updated = $count > 0;
         }
 
         if ($newContent === null) {
-            echo "Error: Pattern replacement failed in {$filePath}\n";
+            fwrite(STDERR, "Error: Pattern replacement failed in {$filePath}\n");
             return false;
         }
 
         if (!$updated) {
-            echo "Warning: No version string found in {$filePath}\n";
+            fwrite(STDERR, "Warning: No version string found in {$filePath}\n");
             return false;
         }
 
         if (file_put_contents($filePath, $newContent) === false) {
-            echo "Error: Unable to write to file: {$filePath}\n";
+            fwrite(STDERR, "Error: Unable to write to file: {$filePath}\n");
             return false;
         }
 
         return true;
     }
 
-    /**
-     * Runs the version bump process.
-     *
-     * Prompts the user to enter a new version string, validates it using the semantic versioning regex pattern,
-     * and updates the version string in all files listed in the $filesToUpdate property.
-     *
-     * If any of the files cannot be updated, an error message is printed and the script exits with a status code of 1.
-     * If no files are updated, an error message is printed and the script exits with a status code of 1.
-     * If not all files are updated, a warning message is printed.
-     *
-     * @return void
-     */
     public function run(): void
     {
-        echo "Current version: {$this->currentVersion}\n";
-        echo "Enter new version (semver): ";
-        $newVersion = trim(fgets(STDIN));
+        global $argv;
 
-        if (!$this->validateNewVersion($newVersion)) {
+        fwrite(STDERR, "Current version: {$this->currentVersion}\n");
+
+        $newVersion = $this->resolveNewVersion($argv[1] ?? null);
+
+        if ($newVersion === null || !$this->validateNewVersion($newVersion)) {
             exit(1);
         }
+
+        if ($newVersion === $this->currentVersion) {
+            fwrite(STDERR, "Error: new version equals current version ({$newVersion}); nothing to do.\n");
+            exit(1);
+        }
+
+        fwrite(STDERR, "New version: {$newVersion}\n");
 
         $successCount = 0;
         foreach ($this->filesToUpdate as $file) {
             if ($this->updateVersionInFile($file, $newVersion)) {
-                echo "Updated version in {$file}\n";
+                fwrite(STDERR, "Updated version in {$file}\n");
                 $successCount++;
             }
         }
 
         if ($successCount === 0) {
-            echo "Error: No files were updated\n";
+            fwrite(STDERR, "Error: No files were updated\n");
             exit(1);
         }
 
         if ($successCount !== count($this->filesToUpdate)) {
-            echo "Warning: Only {$successCount} out of " . count($this->filesToUpdate) . " files were updated\n";
+            fwrite(STDERR, "{$successCount} out of " . count($this->filesToUpdate) . " files were updated\n");
         }
 
-        echo "Version bump completed: {$this->currentVersion} → {$newVersion}\n";
-    }
+        fwrite(STDERR, "Version bump completed: {$this->currentVersion} -> {$newVersion}\n");
 
-    /**
-     * Create a backup of the files to be updated.
-     *
-     * @return bool True if backup was successful, false otherwise.
-     */
-    public function backup(): bool
-    {
-        $backupDir = '.version-bump-backup-' . date('Y-m-d-H-i-s');
-        if (!mkdir($backupDir)) {
-            echo "Error: Unable to create backup directory\n";
-            return false;
-        }
-
-        foreach ($this->filesToUpdate as $file) {
-            if (file_exists($file)) {
-                if (!copy($file, $backupDir . DIRECTORY_SEPARATOR . $file)) {
-                    echo "Error: Failed to backup {$file}\n";
-                    return false;
-                }
-            }
-        }
-
-        return true;
+        echo $newVersion . "\n";
     }
 }
 
-// Execute the script
 $bumper = new VersionBumper();
-
-// Create backup before proceeding
-/*if (!$bumper->backup()) {
-    echo "Error: Backup failed, aborting version bump\n";
-    exit(1);
-}*/
-
 $bumper->run();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Auto version bump & tag
+
+# Bumps the plugin version and pushes a matching git tag whenever a PR is
+# merged into main. Runs AFTER merge, so the version is computed serially from
+# main and can never collide with a version chosen inside a parallel PR.
+#
+# Bump level (default: patch). Override per-release with a marker anywhere in
+# the merge commit message. With GitHub's default squash-merge the PR title
+# becomes that message, so the marker can just go in the PR title:
+#   - "#major" -> X.0.0
+#   - "#minor" -> x.Y.0
+#   - otherwise -> x.y.Z (patch)
+# Include "#norelease" to skip bumping entirely for this merge.
+#
+# Authenticates as a GitHub App (so releases are never tied to a person). The
+# App needs "Contents: Read and write" and must be installed on this repo, with
+# these two secrets available to the repo (set them once at the org level and
+# scope them to the plugin repos):
+#   - RELEASE_APP_ID          the App's numeric App ID
+#   - RELEASE_APP_PRIVATE_KEY the App's generated .pem private key (whole file)
+# The App must also be on the branch-protection / ruleset bypass list for main,
+# otherwise the push below is rejected even with write access.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip the workflow's own bump commit to avoid an infinite loop.
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Resolve App bot user id
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          echo "user-id=$USER_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Determine bump level
+        id: level
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          msg="$COMMIT_MSG"
+          level="patch"
+          if echo "$msg" | grep -qiE '#norelease'; then
+            level="none"
+          elif echo "$msg" | grep -qiE '#major'; then
+            level="major"
+          elif echo "$msg" | grep -qiE '#minor'; then
+            level="minor"
+          fi
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+          echo "Resolved bump level: $level"
+
+      - name: Skip if no release requested
+        if: ${{ steps.level.outputs.level == 'none' }}
+        run: echo "::notice::#norelease present; skipping version bump."
+
+      - name: Bump version
+        if: ${{ steps.level.outputs.level != 'none' }}
+        id: bump
+        run: |
+          NEW_VERSION="$(php ./.ci/version-bump.php ${{ steps.level.outputs.level }} | tail -1)"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumped to $NEW_VERSION"
+
+      - name: Generate changelog entry
+        if: ${{ steps.level.outputs.level != 'none' }}
+        run: php ./.ci/changelog.php "${{ steps.bump.outputs.new_version }}"
+
+      - name: Commit, tag & push
+        if: ${{ steps.level.outputs.level != 'none' }}
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          BOT_USER_ID: ${{ steps.bot.outputs.user-id }}
+        run: |
+          git config user.name  "${APP_SLUG}[bot]"
+          git config user.email "${BOT_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore(release): ${NEW_VERSION}"
+          git tag "${NEW_VERSION}"
+          git push origin HEAD:main
+          git push origin "refs/tags/${NEW_VERSION}"
+          echo "::notice::Released ${NEW_VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this plugin are documented in this file.
+This project adheres to [Semantic Versioning](https://semver.org/).
+
+<!-- new releases inserted below this line -->

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
       "@lint",
       "@test"
     ],
-    "cs:fix": "php-cs-fixer fix"
+    "cs:fix": "php-cs-fixer fix",
+    "version-bump": "@php ./.ci/version-bump.php"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
Ports the release automation from wicket-wp-base-plugin, adapted for a theme: the bumper updates composer.json + the style.css theme header (replacing the repo's previous version-bump.php, which lacked bump-level and CI support). Workflow stages via `git add -A` to capture style.css. See wicket-wp-base-plugin/docs/engineering/release-automation.md for docs.