### PR TITLE
docs: add automated release process guide #norelease

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,37 @@ This repository is a WordPress theme (`wicket-wp-theme`).
   - Linked issue/ticket (if available)
   - Screenshots for UI/template changes
   - Notes on test coverage and any manual verification steps
+
+## Release Process (Automated)
+
+Releases are **fully automated**. Merging a PR to `main` cuts a release via the `wicket-release-bot` GitHub App: it bumps the version, prepends `CHANGELOG.md`, commits `chore(release): x.y.z`, and pushes the matching git tag. No one needs push access to `main`.
+
+**Never do these by hand:** bump the version, edit `composer.json` / the main file header / `*_VERSION` constants (and `style.css` for the theme), or create git tags. The bot owns all of that after merge.
+
+### Releasing (default behavior)
+
+Every PR merged to `main` releases automatically with a **patch** bump. Control the bump by putting a marker in the **PR title** (squash-merge makes the title the commit message):
+
+| Marker | Result |
+|---|---|
+| _(none)_ | patch (`2.4.10` -> `2.4.11`) |
+| `#minor` | minor (`2.4.10` -> `2.5.0`) |
+| `#major` | major (`2.4.10` -> `3.0.0`) |
+| `#norelease` | no bump, no tag |
+
+### Not releasing
+
+Add `#norelease` to the PR title for docs/tooling-only changes that should not cut a version. **Every merge releases unless the message contains `#norelease`.**
+
+### Commit conventions that affect the changelog
+
+- Use conventional prefixes: `feat:`, `fix:`, `docs:`, `chore:`, `perf:`, `refactor:`, etc. The changelog groups entries by prefix.
+- `feat!:` (or any `!:`) flags a **BREAKING** change in the changelog.
+- **Squash-merge** yields the cleanest changelog (one PR = one line). Merge commits list each individual commit.
+- A release lists **everything merged since the last tag**, not just the triggering PR. Catch-up is expected.
+
+### Local version bump (optional)
+
+`composer version-bump` (or `php .ci/version-bump.php`) edits version files only; it never commits or tags. Use it to preview, not to release.
+
+Full details, markers, and troubleshooting: [`docs/engineering/release-automation.md`](docs/engineering/release-automation.md).


### PR DESCRIPTION
## What
Adds an automated release process section to AGENTS.md.

## Why
Release automation is live across the stack, but the guardrails only lived in Slack and the per-repo engineering doc. Putting them in AGENTS.md means anyone working here hits them first.

## How
One standardized block, identical across every release-enabled repo. Covers what the `wicket-release-bot` does on merge, the never-by-hand rule (versions, headers, tags), the `#minor` / `#major` / `#norelease` PR title markers, conventional commit conventions for the changelog, and the local preview command.

## Testing
Docs only. No behavior change.
