### PR TITLE
feat: Sort page family tree by menu_order instead of publish date

### DIFF
--- a/custom/menus.php
+++ b/custom/menus.php
@@ -111,6 +111,8 @@ function wicket_get_all_parent_and_child_pages($post_id, $post_type = 'page')
         'post_status' => 'published',
         'post_type'   => $post_type,
         'post_parent' => $topmost_parent_id,
+        'orderby'     => 'menu_order',
+        'order'       => 'ASC',
     ], 'ARRAY_N');
     foreach ($post_children as $child_id => $child_data) {
         $children_ids_to_add[$child_id] = [];
@@ -131,6 +133,8 @@ function wicket_get_all_parent_and_child_pages($post_id, $post_type = 'page')
             'post_status' => 'published',
             'post_type'   => $post_type,
             'post_parent' => $sibling_id,
+            'orderby'     => 'menu_order',
+            'order'       => 'ASC',
         ], 'ARRAY_N');
         $sibling_children_to_add = [];
         foreach ($sibling_children as $sibling_child_id => $sibling_child_data) {
@@ -151,6 +155,8 @@ function wicket_get_all_parent_and_child_pages($post_id, $post_type = 'page')
                 'post_status' => 'published',
                 'post_type'   => $post_type,
                 'post_parent' => $sibling_2_id,
+                'orderby'     => 'menu_order',
+                'order'       => 'ASC',
             ], 'ARRAY_N');
             $sibling_children_to_add = [];
             foreach ($sibling_2_children as $sibling_child_id => $sibling_child_data) {
@@ -171,6 +177,8 @@ function wicket_get_all_parent_and_child_pages($post_id, $post_type = 'page')
                     'post_status' => 'published',
                     'post_type'   => $post_type,
                     'post_parent' => $sibling_3_id,
+                    'orderby'     => 'menu_order',
+                    'order'       => 'ASC',
                 ], 'ARRAY_N');
                 $sibling_children_to_add = [];
                 foreach ($sibling_3_children as $sibling_child_id => $sibling_child_data) {
@@ -191,6 +199,8 @@ function wicket_get_all_parent_and_child_pages($post_id, $post_type = 'page')
                         'post_status' => 'published',
                         'post_type'   => $post_type,
                         'post_parent' => $sibling_4_id,
+                        'orderby'     => 'menu_order',
+                        'order'       => 'ASC',
                     ], 'ARRAY_N');
                     $sibling_children_to_add = [];
                     foreach ($sibling_4_children as $sibling_child_id => $sibling_child_data) {
@@ -211,6 +221,8 @@ function wicket_get_all_parent_and_child_pages($post_id, $post_type = 'page')
                             'post_status' => 'published',
                             'post_type'   => $post_type,
                             'post_parent' => $sibling_5_id,
+                            'orderby'     => 'menu_order',
+                            'order'       => 'ASC',
                         ], 'ARRAY_N');
                         $sibling_children_to_add = [];
                         foreach ($sibling_5_children as $sibling_child_id => $sibling_child_data) {


### PR DESCRIPTION
## Summary

`wicket_get_all_parent_and_child_pages()` (in `custom/menus.php`) builds its parent/child page tree using `get_children()`, but none of those calls specified an `orderby`, so WordPress defaulted to sorting by publish date (descending) instead of the page's actual position (`menu_order`) set via Page Attributes.

Added `'orderby' => 'menu_order', 'order' => 'ASC'` to all 6 `get_children()` calls in the function (one per tree level, 6 levels deep) so the returned family tree respects each page's configured order.

## End result

Pages returned by `wicket_get_all_parent_and_child_pages()` are now ordered according to their `menu_order` (Page Attributes → Order), matching how they're arranged in wp-admin, instead of being sorted by creation/publish date.

Asana: https://app.asana.com/1/1138832104141584/project/1216279585352304/task/1216640245682866