### PR TITLE
Add wptarl_enabled filter to toggle the API rate-limiter

### DIFF
--- a/custom/api-rate-limiting.php
+++ b/custom/api-rate-limiting.php
@@ -78,6 +78,27 @@ function wptarl_client_ip()
  */
 function wptarl_rest_api_init(WP_REST_Server $wp_rest_server)
 {
+    /**
+     * Master on/off switch for the API rate-limiter.
+     *
+     * Child themes can disable the limiter entirely when a site needs it off,
+     * for example a headless / decoupled storefront whose front-end makes many
+     * legitimate Store API calls per second and does its own throttling:
+     *
+     *     // In the child theme's functions.php
+     *     add_filter('wptarl_enabled', '__return_false');
+     *
+     * This is a deliberate, site-wide feature toggle: it short-circuits before
+     * any client-IP detection or transient bookkeeping runs. If you only need
+     * to exempt specific callers rather than turn the whole limiter off, leave
+     * this enabled and use the finer-grained filters below instead
+     * (wptarl_is_client_rate_limited, wptarl_rate_limited_ips,
+     * wptarl_seconds_between_api_calls).
+     */
+    if (!apply_filters('wptarl_enabled', true)) {
+        return;
+    }
+
     $request_uri = $_SERVER['REQUEST_URI'];
     $is_client_rate_limited = false;
     $transient_key = null;


### PR DESCRIPTION
**Summary**
Adds a master on/off switch to the theme's REST/WooCommerce API rate-limiter (custom/api-rate-limiting.php) so a child theme can disable it entirely when a site needs it off. Single filter, 21-line addition, no behavior change unless a site opts in.

**Why**
The limiter throttles unknown clients to 1 request/sec/IP (and, because the rate-limited-IP list is empty, that currently applies to all non-exempt clients). That's fine for typical traffic but breaks headless/decoupled sites: a normal browse → add-to-cart → checkout flow is 4-5 Store API calls in quick succession, so the front-end randomly gets 429 "Slow down your API calls" partway through checkout. There was no clean, per-site way to turn the limiter off, only per-IP filters that require knowing egress IPs up front.

**What changed**
A new filter at the top of wptarl_rest_api_init():


```
if (!apply_filters('wptarl_enabled', true)) {
    return;
}
```
Sites disable it from their child theme:


`add_filter('wptarl_enabled', '__return_false');`
It short-circuits before client-IP detection and transient bookkeeping run.

**Why a new filter vs. the existing wptarl_is_client_rate_limited**
__return_false on the existing filter does also disable limiting, but that hook's contract is per-client ("should this client be limited?") and it runs late, after the carve-outs. Overloading it as a global kill-switch reads confusingly and is fragile if that branch is ever refactored. wptarl_enabled is an explicit, discoverable feature toggle. Per-client exemptions (wptarl_is_client_rate_limited, wptarl_rate_limited_ips, wptarl_seconds_between_api_calls) are unchanged and still the right tool when you only need to exempt specific callers.

**Impact / risk**
Default behavior unchanged (wptarl_enabled defaults to true). No effect on any site that doesn't add the filter.
Backward compatible; no existing hooks touched.